### PR TITLE
Parser semigroup and monoid instance added

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -30,6 +30,8 @@ parent: Modules
   - [toString (method)](#tostring-method)
 - [end (constant)](#end-constant)
 - [format (function)](#format-function)
+- [getParserMonoid (function)](#getparsermonoid-function)
+- [getParserSemigroup (function)](#getparsersemigroup-function)
 - [int (function)](#int-function)
 - [lit (function)](#lit-function)
 - [parse (function)](#parse-function)
@@ -281,6 +283,27 @@ export function format<A extends object>(formatter: Formatter<A>, a: A, encode: 
 ```
 
 Added in v0.4.0
+
+# getParserMonoid (function)
+
+**Signature**
+
+```ts
+export const getParserMonoid = <A extends object>(): Monoid<Parser<A>> => ...
+```
+
+Added in v0.6.0
+
+# getParserSemigroup (function)
+
+**Signature**
+
+```ts
+export const getParserSemigroup = <A extends object>(): Semigroup<Parser<A>> => ({
+  concat: (x, y) => ...
+```
+
+Added in v0.6.0
 
 # int (function)
 

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -31,7 +31,6 @@ parent: Modules
 - [end (constant)](#end-constant)
 - [format (function)](#format-function)
 - [getParserMonoid (function)](#getparsermonoid-function)
-- [getParserSemigroup (function)](#getparsersemigroup-function)
 - [int (function)](#int-function)
 - [lit (function)](#lit-function)
 - [parse (function)](#parse-function)
@@ -289,17 +288,7 @@ Added in v0.4.0
 **Signature**
 
 ```ts
-export const getParserMonoid = <A extends object>(): Monoid<Parser<A>> => ...
-```
-
-Added in v0.6.0
-
-# getParserSemigroup (function)
-
-**Signature**
-
-```ts
-export const getParserSemigroup = <A extends object>(): Semigroup<Parser<A>> => ({
+export const getParserMonoid = <A extends object>(): Monoid<Parser<A>> => ({
   concat: (x, y) => ...
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import { filter, isEmpty } from 'fp-ts/lib/Record'
 import { failure, Int, string, success, Type } from 'io-ts'
 import { stringify } from 'querystring'
 import { parse as parseUrl } from 'url'
-import { Semigroup } from 'fp-ts/lib/Semigroup'
 import { Monoid } from 'fp-ts/lib/Monoid'
 
 /**
@@ -146,15 +145,8 @@ export function format<A extends object>(formatter: Formatter<A>, a: A, encode: 
 /**
  * @since 0.6.0
  */
-export const getParserSemigroup = <A extends object>(): Semigroup<Parser<A>> => ({
-  concat: (x, y) => x.alt(y)
-})
-
-/**
- * @since 0.6.0
- */
 export const getParserMonoid = <A extends object>(): Monoid<Parser<A>> => ({
-  ...getParserSemigroup<A>(),
+  concat: (x, y) => x.alt(y),
   empty: zero<A>()
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { filter, isEmpty } from 'fp-ts/lib/Record'
 import { failure, Int, string, success, Type } from 'io-ts'
 import { stringify } from 'querystring'
 import { parse as parseUrl } from 'url'
+import { Semigroup } from 'fp-ts/lib/Semigroup'
+import { Monoid } from 'fp-ts/lib/Monoid'
 
 /**
  * @since 0.4.0
@@ -140,6 +142,21 @@ export function parse<A extends object>(parser: Parser<A>, r: Route, a: A): A {
 export function format<A extends object>(formatter: Formatter<A>, a: A, encode: boolean = true): string {
   return formatter.run(Route.empty, a).toString(encode)
 }
+
+/**
+ * @since 0.6.0
+ */
+export const getParserSemigroup = <A extends object>(): Semigroup<Parser<A>> => ({
+  concat: (x, y) => x.alt(y)
+})
+
+/**
+ * @since 0.6.0
+ */
+export const getParserMonoid = <A extends object>(): Monoid<Parser<A>> => ({
+  ...getParserSemigroup<A>(),
+  empty: zero<A>()
+})
 
 /**
  * @since 0.4.0

--- a/test/index.ts
+++ b/test/index.ts
@@ -14,7 +14,8 @@ import {
   zero,
   Formatter,
   succeed,
-  IntegerFromString
+  IntegerFromString,
+  getParserMonoid
 } from '../src'
 import { isLeft } from 'fp-ts/lib/Either'
 import { pipe } from 'fp-ts/lib/pipeable'
@@ -208,6 +209,21 @@ describe('parsers', () => {
   it('lit', () => {
     assert.deepStrictEqual(lit('subview').parser.run(Route.parse('/subview/')), some([{}, new Route([], {})]))
     assert.deepStrictEqual(lit('subview').parser.run(Route.parse('/')), none)
+  })
+
+  it('monoid', () => {
+    const monoid = getParserMonoid<{ v: string }>()
+    const parser = monoid.concat(
+      lit('a')
+        .then(end)
+        .parser.map(() => ({ v: 'a' })),
+      lit('b')
+        .then(end)
+        .parser.map(() => ({ v: 'b' }))
+    )
+    assert.deepStrictEqual(parser.run(Route.parse('/a')), some([{ v: 'a' }, new Route([], {})]))
+    assert.deepStrictEqual(parser.run(Route.parse('/b')), some([{ v: 'b' }, new Route([], {})]))
+    assert.deepStrictEqual(parser.run(Route.parse('/c')), none)
   })
 })
 


### PR DESCRIPTION
Allows the definition of a router via an array instead of repetitive `alt` calls.

```ts
import { fold } from 'fp-ts/es6/Monoid'
import { getParserMonoid } from 'fp-ts-routing'

const router: Parser<Location> = fold(getParserMonoid<Location>())([
  home.parser.map(...),
  user.parser.map(...)
])
```