### PR TITLE
Make query work with partial codecs

### DIFF
--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -14,3 +14,9 @@ pipe(
 declare const BadQuery: t.Type<{ a: string; b: number }, { a: string } & { b: number }>
 // $ExpectError
 R.query(BadQuery)
+
+const PartialQuery = t.partial({ a: t.string });
+R.query(PartialQuery);
+
+const ExactPartialQuery = t.exact(t.partial({ a: t.string }));
+R.query(ExactPartialQuery);

--- a/src/index.ts
+++ b/src/index.ts
@@ -449,7 +449,7 @@ export function lit(literal: string): Match<{}> {
  *
  *  @since 0.4.0
  */
-export function query<A, T>(type: Type<A, Record<keyof T, QueryValues>>): Match<A> {
+export function query<A>(type: Type<A, Record<string, QueryValues>>): Match<A> {
   return new Match(
     new Parser(r => option.map(fromEither(type.decode(r.query)), query => tuple(query, new Route(r.parts, {})))),
     new Formatter((r, query) => new Route(r.parts, type.encode(query)))


### PR DESCRIPTION
Fixes #51 

As the title says.

Partial codecs don't work right now because due to the usage of `Record` in `query<A, T>(codec: t.Type<A, Record<keyof T, ...>>)`. I assume the types were written in this way to overcome the record intersection bug in TS 3.7?

`BadQuery` test fails for TS 3.7 because the following is legit code in TS 3.7:

```
declare const foo: { a: string } & { b: number };
const bar: Record<string, string> = foo;
```

That intersection bug is fixed in TS 3.8.