### PR TITLE
Drop dependencies on `querystring` and `url`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export class Route {
    */
   toString(encode: boolean = true): string {
     const searchParams = Query.toURLSearchParams(this.query)
-    const qs = searchParams.toString().replace(/\+/g, '%20
+    const qs = searchParams.toString().replace(/\+/g, '%20')
     const parts = encode ? this.parts.map(encodeURIComponent) : this.parts
     return '/' + parts.join('/') + (qs ? '?' + qs : '')
   }

--- a/test/index.ts
+++ b/test/index.ts
@@ -63,6 +63,7 @@ describe('Route', () => {
     assert.deepStrictEqual(Route.parse('/%40a'), new Route(['@a'], {}))
     assert.deepStrictEqual(Route.parse('/?a=@b'), new Route([], { a: '@b' }))
     assert.deepStrictEqual(Route.parse('/?@a=b'), new Route([], { '@a': 'b' }))
+    assert.deepStrictEqual(Route.parse('/?a=b&a=c&a=d'), new Route([], { a: ['b', 'c', 'd'] }))
   })
 
   it('parse (decode = false)', () => {
@@ -75,6 +76,7 @@ describe('Route', () => {
     assert.strictEqual(new Route(['a'], { b: 'b' }).toString(), '/a?b=b')
     assert.strictEqual(new Route(['a'], { b: 'b c' }).toString(), '/a?b=b%20c')
     assert.strictEqual(new Route(['a c'], { b: 'b' }).toString(), '/a%20c?b=b')
+    assert.strictEqual(new Route(['a'], { b: ['b', 'c', 'd'] }).toString(), '/a?b=b&b=c&b=d')
     assert.strictEqual(new Route(['@a'], {}).toString(), '/%40a')
     assert.strictEqual(new Route(['a&b'], {}).toString(), '/a%26b')
     assert.strictEqual(new Route([], { a: '@b' }).toString(), '/?a=%40b')


### PR DESCRIPTION
This pull request drops dependencies on Node.js's built-in `querystring` and `url` modules, by switching them to WHATWG's `URLSearchParams` and `URL` APIs internally, which are standardized and widely accepted.

It should also be noted that this pull request makes this library to be available not only on Node.js but also **on the Web out of the box** (namely, without polyfills).

---

Node.js's `url` module [has been deprecated since v11.0.0, and it is encouraged to use the WHATWG `URL` API instead](https://nodejs.org/docs/v11.0.0/api/url.html#url_legacy_url_api).
What is worse, the documentation for `url.parse()` of the latest version of Node.js [points out that it may introduce a security issue](https://nodejs.org/docs/v16.6.0/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost).

> Because the `url.parse()` method uses a lenient, non-standard algorithm for parsing URL strings, security issues can be introduced. 

---

The same applies for `querystring` module. It is also [marked as "legacy" (stability: 3) since v14.17.1, and it is recommended to use WHATWG `URLSearchParams` API instead.](https://nodejs.org/docs/v14.17.1/api/querystring.html#querystring_query_string)

---

The API of the library remains unchanged, however this can potentially introduce breaking changes for some pathological inputs.