### PR TITLE
Support io-ts codecs

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -260,7 +260,9 @@ Will match a querystring.
 **Signature**
 
 ```ts
-export declare function query<A>(type: Type<A, Record<string, QueryValues>>): Match<A>
+export declare function query<A>(
+  type: Type<A, Record<string, QueryValues>> | Codec<unknown, Record<string, QueryValues>, A>
+): Match<A>
 ```
 
 **Example**
@@ -326,12 +328,15 @@ Added in v0.5.1
 
 ## type
 
-`type` matches any io-ts type path component
+`type` matches any io-ts type or codec path component
 
 **Signature**
 
 ```ts
-export declare function type<K extends string, A>(k: K, type: Type<A, string>): Match<{ [_ in K]: A }>
+export declare function type<K extends string, A>(
+  k: K,
+  type: Type<A, string> | Codec<string, string, A>
+): Match<{ [_ in K]: A }>
 ```
 
 **Example**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4747,9 +4747,9 @@
       }
     },
     "io-ts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.0.0.tgz",
-      "integrity": "sha512-6i8PKyNR/dvEbUU9uE+v4iVFU7l674ZEGQsh92y6xEZF/rj46fXbPy+uPPXJEsCP0J0X3UpzXAxp04K4HR2jVw==",
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.16.tgz",
+      "integrity": "sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==",
       "dev": true
     },
     "is-absolute": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dtslint": "github:gcanti/dtslint",
     "fp-ts": "^2.0.1",
     "import-path-rewrite": "github:gcanti/import-path-rewrite",
-    "io-ts": "^2.0.0",
+    "io-ts": "^2.2.16",
     "jest": "^24.8.0",
     "mocha": "^6.1.4",
     "prettier": "^1.19.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -511,8 +511,8 @@ export function query<A>(
   type: Type<A, Record<string, QueryValues>> | Codec<unknown, Record<string, QueryValues>, A>
 ): Match<A> {
   return new Match(
-    // tslint:disable-next-line: deprecation
     new Parser((r) =>
+      // tslint:disable-next-line: deprecation
       option.map(fromEither(type.decode(r.query) as Either<any, A>), (query) => tuple(query, new Route(r.parts, {})))
     ),
     new Formatter((r, query) => new Route(r.parts, type.encode(query)))

--- a/test/index.ts
+++ b/test/index.ts
@@ -45,20 +45,20 @@ export const DateFromISOString = new t.Type(
 const DateFromISOStringC = c.make(
   pipe(
     d.string,
-    d.parse(s => {
+    d.parse((s) => {
       const date = new Date(s)
       return isNaN(date.getTime()) ? d.failure(s, 'Not a valid date') : d.success(date)
     })
   ),
   {
-    encode: date => date.toISOString()
+    encode: (date) => date.toISOString()
   }
 )
 
 const IntegerFromStringC = c.make(
   pipe(
     d.string,
-    d.parse(s => {
+    d.parse((s) => {
       const n = +s
       return isNaN(n) || !Number.isInteger(n) ? d.failure(s, 'Not an integer') : d.success(n)
     })


### PR DESCRIPTION
They're flagged as experimental, but an io-ts `Codec` can be used instead of a `Type` without any code changes. (The cast is unfortunate but harmless...)