### PR TITLE
Remove `querystring` and `url` Node.js core dependencies

### DIFF
--- a/dtslint/ts3.8/tsconfig.json
+++ b/dtslint/ts3.8/tsconfig.json
@@ -11,6 +11,6 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "target": "es5",
-    "lib": ["es2015"]
+    "lib": ["es2015", "dom"]
   }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -57,6 +57,7 @@ describe('Route', () => {
     assert.deepStrictEqual(Route.parse('/foo/bar/'), new Route(['foo', 'bar'], {}))
     assert.deepStrictEqual(Route.parse('/foo/bar?a=1'), new Route(['foo', 'bar'], { a: '1' }))
     assert.deepStrictEqual(Route.parse('/foo/bar/?a=1'), new Route(['foo', 'bar'], { a: '1' }))
+    assert.deepStrictEqual(Route.parse('/foo/bar?a=1&a=2&a=3'), new Route(['foo', 'bar'], { a: ['1', '2', '3'] }))
     assert.deepStrictEqual(Route.parse('/a%20b'), new Route(['a b'], {}))
     assert.deepStrictEqual(Route.parse('/foo?a=b%20c'), new Route(['foo'], { a: 'b c' }))
     assert.deepStrictEqual(Route.parse('/@a'), new Route(['@a'], {}))
@@ -73,7 +74,9 @@ describe('Route', () => {
     assert.strictEqual(new Route([], {}).toString(), '/')
     assert.strictEqual(new Route(['a'], {}).toString(), '/a')
     assert.strictEqual(new Route(['a'], { b: 'b' }).toString(), '/a?b=b')
-    assert.strictEqual(new Route(['a'], { b: 'b c' }).toString(), '/a?b=b%20c')
+    assert.strictEqual(new Route(['a'], { b: 'b c' }).toString(), '/a?b=b+c')
+    assert.strictEqual(new Route(['a'], { b: ['1', '2', '3'] }).toString(), '/a?b=1&b=2&b=3')
+    assert.strictEqual(new Route(['a'], { b: undefined }).toString(), '/a')
     assert.strictEqual(new Route(['a c'], { b: 'b' }).toString(), '/a%20c?b=b')
     assert.strictEqual(new Route(['@a'], {}).toString(), '/%40a')
     assert.strictEqual(new Route(['a&b'], {}).toString(), '/a%26b')
@@ -95,7 +98,7 @@ describe('Route', () => {
   })
 
   it('parse and toString should be inverse functions', () => {
-    const path = '/a%20c?b=b%20c'
+    const path = '/a%20c?b=b+c'
     assert.strictEqual(Route.parse(path).toString(), path)
   })
 


### PR DESCRIPTION
This PR will remove `querystring` and `url` Node.js core dependencies in favor of standard [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL_API) web API (also [supported by Node.js](https://nodejs.org/dist/latest-v18.x/docs/api/url.html#the-whatwg-url-api) from v10.0.0)

Resolves #58 