### PR TITLE
Type `Route#toString` as `/${string}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 **Note**: Gaps between patch versions are faulty/broken releases. **Note**: A feature tagged as Experimental is in a
 high state of flux, you're at risk of it changing without notice.
 
+# 0.7.0
+
+- **Polish**
+  - Type `Route#toString` as `/${string}`
+
 # 0.6.0
 
 - **New Feature**

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ npm i fp-ts-routing
 
 # TypeScript compatibility
 
-The stable version is tested against TypeScript 3.5.2 but should run with 3.2.2+ too.
+| `fp-ts-routing` version | required `typescript` version                                  |
+| ----------------------- | -------------------------------------------------------------- |
+| 0.7.0+                  | 4.1+                                                           |
+| <= 0.6.0                | tested against TypeScript 3.5.2 but should run with 3.2.2+ too |
 
 # Usage
 
@@ -51,10 +54,7 @@ const defaults = end
 const homeMatch = lit('home').then(end)
 const userIdMatch = lit('users').then(int('userId'))
 const userMatch = userIdMatch.then(end)
-const invoiceMatch = userIdMatch
-  .then(lit('invoice'))
-  .then(int('invoiceId'))
-  .then(end)
+const invoiceMatch = userIdMatch.then(lit('invoice')).then(int('invoiceId')).then(end)
 
 // router
 const router = zero<Location>()

--- a/docs/modules/route.ts.md
+++ b/docs/modules/route.ts.md
@@ -83,7 +83,7 @@ Added in v0.4.0
 **Signature**
 
 ```ts
-toString(encode: boolean = true): string
+toString(encode: boolean = true): `/${string}`
 ```
 
 Added in v0.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-routing",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A type-safe routing library for TypeScript",
   "files": [
     "lib",

--- a/src/route.ts
+++ b/src/route.ts
@@ -47,10 +47,10 @@ export class Route {
   /**
    * @since 0.4.0
    */
-  toString(encode: boolean = true): string {
+  toString(encode: boolean = true): `/${string}` {
     const qs = fromQuery(this.query).toString()
     const parts = encode ? this.parts.map(encodeURIComponent) : this.parts
-    return '/' + parts.join('/') + (qs ? '?' + qs : '')
+    return `/${parts.join('/')}${qs ? '?' + qs : ''}`
   }
 }
 


### PR DESCRIPTION
Updates the return type of `Route#toString` to be `/${string}`. This is a nice enhancement for code where it's important to distinguish between relative and absolute URLs in the type system.